### PR TITLE
헬스 커넥트 연동->걸음수 데이터 직접 접근(헬스커넥트 사용 x)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.databinding:databinding-runtime:8.1.0'
     implementation 'androidx.work:work-runtime-ktx:2.8.1'
+    implementation 'androidx.lifecycle:lifecycle-service:2.6.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,9 @@
     <uses-permission android:name="android.permission.health.WRITE_STEPS"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+    <uses-permission android:name="android.permission.BODY_SENSORS" />
+
 
 
     <application

--- a/app/src/main/java/com/example/pedometer/Model/StepViewModel.kt
+++ b/app/src/main/java/com/example/pedometer/Model/StepViewModel.kt
@@ -12,7 +12,6 @@ import java.util.*
 
 
 class StepViewModel(private val stepRepository: StepRepository) : ViewModel() {//걸음수 뷰모델
-
     private val _stepsToday: MutableLiveData<Int> by lazy { MutableLiveData() }
     private val _stepsAvg: MutableLiveData<Int> by lazy { MutableLiveData() }
     private val _stepsGoal: MutableLiveData<Int> by lazy { MutableLiveData() }

--- a/app/src/main/java/com/example/pedometer/Model/StepsDAO.kt
+++ b/app/src/main/java/com/example/pedometer/Model/StepsDAO.kt
@@ -1,16 +1,16 @@
 package com.example.pedometer.Model
 
-import androidx.room.Dao
-import androidx.room.Delete
-import androidx.room.Insert
+import androidx.room.*
 import androidx.room.OnConflictStrategy.Companion.REPLACE
-import androidx.room.Query
 import java.util.*
 
 @Dao
 interface StepsDAO {
     @Insert(onConflict = REPLACE)
     fun insert(steps : StepsEntity)
+
+    @Update
+    fun update(steps: StepsEntity)
 
     @Query("SELECT * FROM steps")
     fun getAll() : List<StepsEntity>
@@ -19,5 +19,7 @@ interface StepsDAO {
     fun delete(steps: StepsEntity)
     @Query("SELECT * FROM steps WHERE date = :date")
     fun getByDate(date: Long): StepsEntity?
+    @Query("SELECT * FROM steps WHERE date BETWEEN :startTime AND :endTime")
+    fun getStepsBetweenDates(startTime: Long, endTime: Long): List<StepsEntity>
 
 }

--- a/app/src/main/java/com/example/pedometer/Model/StepsDatabase.kt
+++ b/app/src/main/java/com/example/pedometer/Model/StepsDatabase.kt
@@ -5,11 +5,13 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 
-@Database(entities = [StepsEntity::class], version = 1)
+@Database(entities = [StepsEntity::class], version = 1, exportSchema = false)
 abstract class StepsDatabase : RoomDatabase() {
+
     abstract fun stepsDAO(): StepsDAO
 
     companion object {
+        @Volatile
         private var INSTANCE: StepsDatabase? = null
 
         fun getInstance(context: Context): StepsDatabase {
@@ -17,10 +19,8 @@ abstract class StepsDatabase : RoomDatabase() {
                 val instance = Room.databaseBuilder(
                     context.applicationContext,
                     StepsDatabase::class.java,
-                    "steps.db"
-                )
-                    .fallbackToDestructiveMigration()
-                    .build()
+                    "steps_database"
+                ).build()
                 INSTANCE = instance
                 instance
             }

--- a/app/src/main/java/com/example/pedometer/Model/StepsEntity.kt
+++ b/app/src/main/java/com/example/pedometer/Model/StepsEntity.kt
@@ -7,7 +7,7 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "steps")
 data class StepsEntity(
     @PrimaryKey(autoGenerate = false)
-    var date: String="",
+    var date: Long = 0L, // 날짜를 Long 타입으로 저장
     @ColumnInfo(name="todaySteps")
     var todaySteps: Int?,
     @ColumnInfo(name="goalSteps")

--- a/app/src/main/java/com/example/pedometer/MyApplication.kt
+++ b/app/src/main/java/com/example/pedometer/MyApplication.kt
@@ -12,6 +12,10 @@ class MyApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         Log.e("MyApplication","Myapllication 활성화")
+        val stepSensorHelper = StepSensorHelper(this) // context를 전달하여 초기화
+        stepSensorHelper.startListening()
+        Log.e("MyApplication","stepsensor 활성화")
+
         // 추가: 백그라운드 작업 스케줄링 호출
         scheduleDailyWork(this)
     }
@@ -21,26 +25,27 @@ class MyApplication : Application() {
             .build()
 
         val workRequest = PeriodicWorkRequestBuilder<MyWorker>(
-            repeatInterval = 1,
-            repeatIntervalTimeUnit = TimeUnit.DAYS
+            repeatInterval = 1, // 1 시간마다 호출
+            repeatIntervalTimeUnit = TimeUnit.HOURS // 시간 단위로 설정
         )
             .setConstraints(constraints)
             .setInitialDelay(calculateInitialDelay(), TimeUnit.MILLISECONDS)
             .build()
 
         WorkManager.getInstance(context).enqueueUniquePeriodicWork(
-            "daily_work",
+            "hourly_work",
             ExistingPeriodicWorkPolicy.KEEP,
             workRequest
         )
-        Log.e("MyApplication","MyWorker 호출")
+        Log.e("MyApplication", "MyWorker 호출")
     }
+
 
     private fun calculateInitialDelay(): Long {
         val currentTime = Calendar.getInstance()
         val targetTime = Calendar.getInstance()
-        targetTime.set(Calendar.HOUR_OF_DAY, 20)
-        targetTime.set(Calendar.MINUTE, 56)
+        targetTime.set(Calendar.HOUR_OF_DAY, 24)
+        targetTime.set(Calendar.MINUTE, 0)
         targetTime.set(Calendar.SECOND, 0)
         targetTime.set(Calendar.MILLISECOND, 0)
 

--- a/app/src/main/java/com/example/pedometer/MyForegroundService.kt
+++ b/app/src/main/java/com/example/pedometer/MyForegroundService.kt
@@ -5,50 +5,68 @@ import android.annotation.SuppressLint
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
-import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
 import android.content.pm.PackageManager
-import android.os.IBinder
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.lifecycle.LifecycleService
+import androidx.lifecycle.lifecycleScope
+import com.example.pedometer.Model.StepsDAO
+import com.example.pedometer.Model.StepsDatabase
 import com.example.pedometer.R.string.notification_channel_description
 import com.example.pedometer.R.string.notification_channel_name
+import com.example.pedometer.repository.StepRepository
+import com.example.pedometer.repository.StepRepositoryImpl
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
-class MyForegroundService : Service() {//걸음수 데이터 상태바에 알림
+class MyForegroundService : LifecycleService() {
 
     private val notificationChannelID = "StepNotificationChannel"
     private val notificationID = 1
+    private lateinit var stepRepository: StepRepository
+    private lateinit var stepsDAO: StepsDAO
+    private val viewModelScope = CoroutineScope(Dispatchers.Main)
+    private lateinit var sharedPreferences: SharedPreferences
+
+    override fun onCreate() {
+        super.onCreate()
+        stepsDAO = StepsDatabase.getInstance(applicationContext).stepsDAO()
+    }
 
     @SuppressLint("UnspecifiedImmutableFlag")
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        super.onStartCommand(intent, flags, startId)
         createNotificationChannel()
+        sharedPreferences = getSharedPreferences("stepsData", MODE_PRIVATE)
 
-        val stepsToday = intent?.getIntExtra("stepsToday", 0) ?: 0
-        val stepsGoal = intent?.getIntExtra("stepsGoal", 0) ?: 0
-        val stepsPercent = if (stepsGoal > 0) (stepsToday.toDouble() / stepsGoal.toDouble() * 100).toInt() else 0
+        stepRepository = StepRepositoryImpl(this, stepsDAO)
+        lifecycleScope.launch {
+            val stepsToday = sharedPreferences.getInt("stepsToday",0)
+            val stepsGoal = sharedPreferences.getInt("stepsGoal",0)
+            val stepsPercent = if (stepsGoal > 0) ((stepsToday.toDouble() ?: 0.0) / stepsGoal.toDouble() * 100).toInt() else 0
 
-        val notificationContent = getString(
-            R.string.notification_content_text,
-            stepsToday,
-            stepsGoal,
-            stepsPercent
-        )
+            val notificationContent = getString(
+                R.string.notification_content_text,
+                stepsToday,
+                stepsGoal,
+                stepsPercent
+            )
 
-        val notificationIntent = Intent(this, MainActivity::class.java)
-        val pendingIntent = PendingIntent.getActivity(this, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE)
+            val notificationIntent = Intent(this@MyForegroundService, MainActivity::class.java)
+            val pendingIntent = PendingIntent.getActivity(this@MyForegroundService, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE)
 
-        val notification = buildNotification(notificationContent, pendingIntent)
+            val notification = buildNotification(notificationContent, pendingIntent)
 
-        showNotification(notification)
-
+            showNotification(notification)
+        }
         return START_NOT_STICKY
     }
 
-    override fun onBind(intent: Intent?): IBinder? {
-        return null
-    }
 
     private fun createNotificationChannel() {
         val channel = NotificationChannel(
@@ -86,7 +104,6 @@ class MyForegroundService : Service() {//걸음수 데이터 상태바에 알림
             }
             NotificationManagerCompat.from(this).notify(notificationID, notification.build())
         } else {
-            // Handle case where notifications are not enabled (optional)
             val settingsIntent = Intent().apply {
                 action = "android.settings.APP_NOTIFICATION_SETTINGS"
                 putExtra("android.provider.extra.APP_PACKAGE", packageName)
@@ -101,5 +118,4 @@ class MyForegroundService : Service() {//걸음수 데이터 상태바에 알림
             NotificationManagerCompat.from(this).notify(notificationID, notificationWithoutPermission.build())
         }
     }
-
 }

--- a/app/src/main/java/com/example/pedometer/MyWorker.kt
+++ b/app/src/main/java/com/example/pedometer/MyWorker.kt
@@ -1,122 +1,20 @@
 package com.example.pedometer
 
 import android.content.Context
-import android.icu.text.SimpleDateFormat
-import android.icu.util.Calendar
-import android.util.Log
-import androidx.health.connect.client.HealthConnectClient
-import androidx.health.connect.client.permission.HealthPermission
-import androidx.health.connect.client.records.StepsRecord
-import androidx.health.connect.client.request.AggregateRequest
-import androidx.health.connect.client.time.TimeRangeFilter
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.work.*
-import com.example.pedometer.Model.StepsDatabase
-import com.example.pedometer.Model.StepsEntity
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import java.time.Instant
-import java.util.*
-import java.util.concurrent.TimeUnit
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
 
 class MyWorker(context: Context, workerParameters: WorkerParameters) : CoroutineWorker(context, workerParameters) {
 
     // 주기적인 백그라운드 작업을 정의하고 수행하기 위한 공간
-    override suspend fun doWork(): Result { // 코루틴을 사용하여 suspend 함수로 변경(백그라운드에서 헬스커넥트 사용하기 위함)
-        return try {
-            val date = Calendar.getInstance().time
-            val formattedDate = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(date)
-            val stepsEntity = StepsEntity(
-                date = formattedDate,
-                todaySteps = getStepsToday(applicationContext).value,
-                goalSteps = getStepsGoal(applicationContext).value
-            )
-            Log.e("MyWorker","데이터 저장 시작")
+    override suspend fun doWork(): Result {
+        try {
+            val stepSensorHelper = StepSensorHelper(applicationContext)
+            stepSensorHelper.startListening() // StepSensorHelper 호출/ 걸음수 측 정 및 데이터 베이스에 저장
 
-            // 백그라운드 스레드에서 데이터베이스에 접근하여 저장
-            val stepsDAO = StepsDatabase.getInstance(applicationContext).stepsDAO()
-            CoroutineScope(Dispatchers.IO).launch {
-                stepsDAO.insert(stepsEntity)
-            }
-
-            Log.e("MyWorker","데이터 저장 완료")
-
-
-            Result.success() // 작업 성공을 return
+            return Result.success()
         } catch (e: Exception) {
-            Result.failure()
+            return Result.failure()
         }
-    }
-
-    private suspend fun getStepsToday(applicationContext: Context): LiveData<Int> {
-        val healthConnectClient = HealthConnectClient.getOrCreate(applicationContext)
-        val permissions = setOf(HealthPermission.getReadPermission(StepsRecord::class))
-        val granted = healthConnectClient.permissionController.getGrantedPermissions()
-
-        if (granted.containsAll(permissions)) {
-            val startTime = Calendar.getInstance()
-            startTime.set(Calendar.HOUR_OF_DAY, 0)
-            startTime.set(Calendar.MINUTE, 0)
-            startTime.set(Calendar.SECOND, 0)
-            startTime.set(Calendar.MILLISECOND, 0)
-            val currentDayStart = startTime.timeInMillis
-            val endTime = Instant.now().toEpochMilli()
-
-            try {
-                val response = healthConnectClient.aggregate(
-                    AggregateRequest(
-                        metrics = setOf(StepsRecord.COUNT_TOTAL),
-                        timeRangeFilter = TimeRangeFilter.between(
-                            startTime = Instant.ofEpochMilli(currentDayStart),
-                            endTime = Instant.ofEpochMilli(endTime)
-                        )
-                    )
-                )
-                val stepCount = response[StepsRecord.COUNT_TOTAL]
-                return MutableLiveData(stepCount?.toInt() ?: 0)
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
-        }
-
-        return MutableLiveData(0)
-    }
-
-    private fun getStepsGoal(applicationContext: Context): LiveData<Int> {
-        val sharedPrefs = applicationContext.getSharedPreferences("stepsData", Context.MODE_PRIVATE)
-        val stepsGoal = sharedPrefs.getInt("stepsGoal", 0)
-        return MutableLiveData(stepsGoal)
-    }
-
-    fun scheduleDailyWork(context: Context) {
-        val constraints = Constraints.Builder()
-            .setRequiredNetworkType(NetworkType.CONNECTED)
-            .build()
-
-        val workRequest = PeriodicWorkRequestBuilder<MyWorker>(
-            repeatInterval = 1,
-            repeatIntervalTimeUnit = TimeUnit.DAYS
-        )
-            .setConstraints(constraints)
-            .setInitialDelay(calculateInitialDelay(), TimeUnit.MILLISECONDS)
-            .build()
-
-        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
-            "daily_work",
-            ExistingPeriodicWorkPolicy.KEEP,
-            workRequest
-        )
-    }
-
-    private fun calculateInitialDelay(): Long {
-        val currentTime = Calendar.getInstance()
-        val targetTime = Calendar.getInstance()
-        targetTime.set(Calendar.HOUR_OF_DAY, 23)
-        targetTime.set(Calendar.MINUTE, 59)
-        targetTime.set(Calendar.SECOND, 0)
-        targetTime.set(Calendar.MILLISECOND, 0)
-        return targetTime.timeInMillis - currentTime.timeInMillis
     }
 }

--- a/app/src/main/java/com/example/pedometer/StepSensorHelper.kt
+++ b/app/src/main/java/com/example/pedometer/StepSensorHelper.kt
@@ -1,0 +1,80 @@
+package com.example.pedometer
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.example.pedometer.Model.StepsDatabase
+import com.example.pedometer.Model.StepsEntity
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+
+class StepSensorHelper(private val context: Context) : SensorEventListener {
+
+    private val sensorManager: SensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+    private val stepSensor: Sensor? = sensorManager.getDefaultSensor(Sensor.TYPE_STEP_COUNTER)
+
+    private var _stepsToday = MutableLiveData<Int>()
+    val stepsToday: LiveData<Int>
+        get() = _stepsToday
+
+    init {
+        startListening()
+    }
+
+    fun startListening() {
+        stepSensor?.let { sensor ->
+            sensorManager.registerListener(this, sensor, SensorManager.SENSOR_DELAY_NORMAL)
+        }
+        saveStepsToDatabase(stepsToday.value ?: 0) // 측정된 걸음수를 데이터베이스에 저장
+    }
+
+    fun stopListening() {
+        sensorManager.unregisterListener(this)
+    }
+
+    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
+        // Do nothing
+    }
+
+    override fun onSensorChanged(event: SensorEvent?) {
+        event?.let {
+            if (it.sensor == stepSensor) {
+                val steps = it.values[0].toInt()
+                _stepsToday.postValue(steps) // LiveData 값을 업데이트
+                saveStepsToDatabase(steps)
+            }
+        }
+    }
+
+    @OptIn(DelicateCoroutinesApi::class)
+    private fun saveStepsToDatabase(steps: Int) {
+        val currentTimeMillis = System.currentTimeMillis()
+        val sharedPrefs = context.getSharedPreferences("stepsData", Context.MODE_PRIVATE)
+
+        val stepsDAO = StepsDatabase.getInstance(context).stepsDAO()
+
+        GlobalScope.launch(Dispatchers.IO) {
+            val existingEntity = stepsDAO.getByDate(currentTimeMillis)
+
+            if (existingEntity != null) {
+                // 이미 해당 날짜의 Entity가 존재하면 업데이트
+                existingEntity.todaySteps = steps
+                existingEntity.goalSteps=sharedPrefs.getInt("stepsGoal",0)
+                stepsDAO.update(existingEntity)
+            } else {
+                // 해당 날짜의 Entity가 없으면 새로 생성
+                val stepsEntity = StepsEntity(
+                    date = currentTimeMillis,
+                    todaySteps = steps,
+                    goalSteps = sharedPrefs.getInt("stepsGoal", 0)
+                )
+                stepsDAO.insert(stepsEntity)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/pedometer/fragment/Day.kt
+++ b/app/src/main/java/com/example/pedometer/fragment/Day.kt
@@ -4,16 +4,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.lifecycle.LiveData
 import com.example.pedometer.BaseFragment
-import com.example.pedometer.Model.StepsEntity
 import com.example.pedometer.R
 import com.example.pedometer.databinding.FragmentDayBinding
 import com.github.mikephil.charting.data.PieData
 import com.github.mikephil.charting.data.PieDataSet
 import com.github.mikephil.charting.data.PieEntry
 
-class Day(private val stepsCount: LiveData<StepsEntity>, private val stepsGoal: Int, private val selectedMonth: Int, private val selectedDay: Int) : BaseFragment<FragmentDayBinding>() {
+class Day(private val stepsCount: Int, private val stepsGoal: Int, private val selectedMonth: Int, private val selectedDay: Int) : BaseFragment<FragmentDayBinding>() {
 
     override fun getFragmentBinding(
         inflater: LayoutInflater,
@@ -28,16 +26,14 @@ class Day(private val stepsCount: LiveData<StepsEntity>, private val stepsGoal: 
     }
 
     private fun updatePieChart() {
-        val stepsEntity = stepsCount.value
-        val stepsCountValue = stepsEntity?.todaySteps ?: 0 // stepsEntity에서 실제 걸음 수 값을 가져옴
 
-        val stepsRemain = stepsGoal - stepsCountValue // 남은 걸음수 설정
-        binding.viewSteps.text = getString(R.string.steps_percentage, stepsCountValue.toString(), stepsGoal.toString())
+        val stepsRemain = stepsGoal - stepsCount // 남은 걸음수 설정
+        binding.viewSteps.text = getString(R.string.steps_percentage, stepsCount.toString(), stepsGoal.toString())
         binding.viewDate.text = getString(R.string.current_date, selectedMonth.toString(), selectedDay.toString())
 
 
         val entries = ArrayList<PieEntry>() // 파이차트 데이터 리스트
-        entries.add(PieEntry(stepsCountValue.toFloat(), "이만큼 걸었어요"))
+        entries.add(PieEntry(stepsCount.toFloat(), "이만큼 걸었어요"))
         entries.add(PieEntry(stepsRemain.toFloat(), "이만큼 남았어요"))
 
         val dataSet = PieDataSet(entries, "Sample Data") // 파이차트 설정

--- a/app/src/main/java/com/example/pedometer/repository/StepRepository.kt
+++ b/app/src/main/java/com/example/pedometer/repository/StepRepository.kt
@@ -2,12 +2,11 @@ package com.example.pedometer.repository
 
 import androidx.lifecycle.LiveData
 
-interface StepRepository {//걸음수 레포지토리
+interface StepRepository {
     suspend fun getStepsToday(): LiveData<Int>
     suspend fun getStepsAvg(): LiveData<Int>
-    suspend fun getDate(): LiveData<Int>
+    suspend fun getDate(): LiveData<Long>
     suspend fun getStepsGoal(): LiveData<Int>
     suspend fun updateStepsNow()
     suspend fun updateStepsAverage()
-
 }

--- a/app/src/main/java/com/example/pedometer/repository/StepRepositoryImpl.kt
+++ b/app/src/main/java/com/example/pedometer/repository/StepRepositoryImpl.kt
@@ -1,28 +1,26 @@
 package com.example.pedometer.repository
 
 import android.content.Context
-import androidx.health.connect.client.HealthConnectClient
-import androidx.health.connect.client.permission.HealthPermission
-import androidx.health.connect.client.records.StepsRecord
-import androidx.health.connect.client.request.AggregateRequest
-import androidx.health.connect.client.time.TimeRangeFilter
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
 import com.example.pedometer.Model.StepsDAO
+import com.example.pedometer.StepSensorHelper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.time.Instant
-import java.util.*
 
-@Suppress("UNREACHABLE_CODE")
+@Suppress("UNREACHABLE_CODE", "DEPRECATION")
 class StepRepositoryImpl(
         private val context: Context,
         private val stepsDAO: StepsDAO
 ) : StepRepository {
-        private val healthConnectClient = HealthConnectClient.getOrCreate(context)
-
+        private val stepSensorHelper = StepSensorHelper(context) // StepSensorHelper 인스턴스 생성
         private var _stepsToday = MutableLiveData<Int>()
         private var _stepsAvg = MutableLiveData<Int>()
         private var _stepsGoal = MutableLiveData<Int>()
-        private var _date = MutableLiveData<Int>()
+        private var _date = MutableLiveData<Long>()
 
         override suspend fun getStepsToday(): LiveData<Int> {
                 updateStepsNow()
@@ -39,94 +37,53 @@ class StepRepositoryImpl(
                 _stepsGoal.value = stepsGoal
                 return _stepsGoal
         }
-        override suspend fun getDate(): LiveData<Int> {
-
-                _date.value =
+        override suspend fun getDate(): LiveData<Long> {
+                val currentDate = System.currentTimeMillis()
+                _date.value = currentDate
                 return _date
         }
 
+
+
         override suspend fun updateStepsNow() {
-                // Health Connect SDK 사용하여 현재 걸음 수 업데이트
-                val permissions = setOf(HealthPermission.getReadPermission(StepsRecord::class))
-                val granted = healthConnectClient.permissionController.getGrantedPermissions()
-
-                if (granted.containsAll(permissions)) {
-                        readStepsDataToday()
+                try {
+                        val stepsTodayLiveData = stepSensorHelper.stepsToday
+                        stepsTodayLiveData.observeForever(object : Observer<Int> {
+                                override fun onChanged(value: Int) {
+                                        _stepsToday.postValue(value) // LiveData에 값을 업데이트
+                                        stepsTodayLiveData.removeObserver(this) // 옵저버 해제
+                                }
+                        })
+                } catch (e: Exception) {
+                        e.printStackTrace()
                 }
-
         }
+
 
         override suspend fun updateStepsAverage() {
-                // Health Connect SDK 사용하여 평균 걸음 수 업데이트
-                val permissions = setOf(HealthPermission.getReadPermission(StepsRecord::class))
-                val granted = healthConnectClient.permissionController.getGrantedPermissions()
+                _stepsAvg.postValue(0)
+                CoroutineScope(Dispatchers.IO).launch {
+                        // 현재 시간을 가져와서 endTime으로 설정
+                        val endTime = Instant.now().toEpochMilli()
+                        // 1주일 전의 시간을 가져와서 startTime으로 설정
+                        val startTime = Instant.now().minusSeconds(7 * 24 * 60 * 60).toEpochMilli()
 
-                if (granted.containsAll(permissions)) {
-                        readStepsDataAvg()
-                }
-        }
+                        try {
+                                // 룸 데이터베이스에서 해당 기간 동안의 걸음수 데이터 가져오기
+                                val stepsFromDatabase = stepsDAO.getStepsBetweenDates(startTime, endTime)
 
+                                val totalDays = 7
+                                val totalStepsFromDatabase = stepsFromDatabase.sumBy { it.todaySteps ?: 0 } // 데이터가 없는 경우 0으로 처리
 
+                                // 일주일간의 평균 걸음수 계산
+                                val averageSteps = totalStepsFromDatabase.toFloat() / totalDays
 
-        private suspend fun readStepsDataToday() {
-                // 현재 시간을 가져와서 endTime으로 설정
-                val endTime = Instant.now().toEpochMilli()
-                // 당일 00시를 startTime으로 설정
-                val startTime = Calendar.getInstance()
-                startTime.set(Calendar.HOUR_OF_DAY, 0)
-                startTime.set(Calendar.MINUTE, 0)
-                startTime.set(Calendar.SECOND, 0)
-                startTime.set(Calendar.MILLISECOND, 0)
-                val currentDayStart = startTime.timeInMillis
-                try {
-                        // 걸음 수 데이터 읽기
-                        val response = healthConnectClient.aggregate(
-                                AggregateRequest(
-                                        metrics = setOf(StepsRecord.COUNT_TOTAL),
-                                        timeRangeFilter = TimeRangeFilter.between(
-                                                startTime = Instant.ofEpochMilli(currentDayStart),
-                                                endTime = Instant.ofEpochMilli(endTime)
-                                        )
-                                )
-                        )
-                        val stepCount = response[StepsRecord.COUNT_TOTAL] as Long?
-
-                        stepCount?.let {
-                                _stepsToday.postValue(it.toInt())//라이브 데이터에 저장
+                                // 업데이트된 stepsAvg를 화면에 표시
+                                _stepsAvg.postValue(averageSteps.toInt()) // 라이브 데이터에 저장
+                        } catch (e: Exception) {
+                                // 걸음 수 데이터 읽기 실패 시 에러 처리
+                                e.printStackTrace()
                         }
-                } catch (e: Exception) {
-                        // 걸음 수 데이터 읽기 실패 시 에러 처리
-                        e.printStackTrace()
                 }
         }
-
-        private suspend fun readStepsDataAvg() {
-                // 현재 시간을 가져와서 endTime으로 설정
-                val endTime = Instant.now()
-                // 1주일 전의 시간을 가져와서 startTime으로 설정
-                val startTime = Instant.now().minusSeconds(7 * 24 * 60 * 60)
-
-                try {
-                        // 걸음 수 데이터 읽기
-                        val response = healthConnectClient.aggregate(
-                                AggregateRequest(
-                                        metrics = setOf(StepsRecord.COUNT_TOTAL),
-                                        timeRangeFilter = TimeRangeFilter.between(startTime, endTime)
-                                )
-                        )
-                        val stepCount = response[StepsRecord.COUNT_TOTAL] as Long?
-                        // 일주일간의 평균 걸음수 계산
-                        val averageSteps = stepCount?.toFloat()?.div(7)?.toInt() ?: 0
-
-                        // 업데이트된 stepsNow와 stepsAvg를 화면에 표시
-                        stepCount?.let {
-                                _stepsAvg.postValue(averageSteps)//라이브 데이터에 저장
-                        }
-                } catch (e: Exception) {
-                        // 걸음 수 데이터 읽기 실패 시 에러 처리
-                        e.printStackTrace()
-                        // 또는 다른 방식으로 로그 출력
-                }
-        }
-
 }


### PR DESCRIPTION
작업 요약 
- 헬스 커넥트 연동 시 백그라운드 데이터 동기화가 불가능하여 걸음수 센서에 직접 접근하여 걸음수 데이터를 가져오는 방식으로 변경

작업 세부
- StepSensorHelper : 걸음수 측정 후 데이터 베이스에 저장하는 클래스
- Myworker에서 StepSensorHelper를 호출하고 Myapplication에서 Myworker를 한시간에 한번씩 호출(단, 날짜를 확인해서 만약 이미 Entity가 생성된 경우 새로운 Entity를 생성하지 않고 해당 Entity 내에 있는 걸음수 데이터만 업데이트 하도록 설정)
- 매 시간마다 걸음수가 업데이트 되고 24시가 지나면 다음 날짜로 새로운 entity 생성

해결해야 할 문제들
- 아직 첫 화면에서 걸음수가 0으로뜨는 문제(steprepositoryimpl에서부터 stepsToday 값이 null로 전달됨)이 해결되지 않음(두번 접속하면 값이 잘 나옴)
- 일주일간 평균 걸음수가 수식 오류 혹은 중첩으로 인해 onResume단계에서 중복 호출될 때마다 값이 증가함